### PR TITLE
Linux Bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ sudo apt-get install xvfb libfontconfig wkhtmltopdf
 
 ## macOS
 ```bash
-brew install wkhtmltopdf
+brew cask install wkhtmltopdf
 ```
 
 ## Swift Package Manager

--- a/Sources/WKHTMLTOPDF/WK.swift
+++ b/Sources/WKHTMLTOPDF/WK.swift
@@ -7,7 +7,11 @@ public typealias WK = WKHTMLTOPDF
 
 public class WKHTMLTOPDF {
     private var params: [GeneralParam] = []
+    #if os(Linux)
+    private var pathToBinary = "/usr/bin/wkhtmltopdf"
+    #else
     private var pathToBinary = "/usr/local/bin/wkhtmltopdf"
+    #endif
     private var tmpDir = "/tmp/wkhtmltopdf"
     
     public init (pathToBinary: String? = nil, tmpDir: String? = nil, _ params: GeneralParam...) {
@@ -40,6 +44,9 @@ public class WKHTMLTOPDF {
             }
             let wk = Process()
             let stdout = Pipe()
+            defer {
+                stdout.fileHandleForReading.closeFile()
+            }
             wk.launchPath = self.pathToBinary
             if !self.params.contains(.quiet()) {
                 self.params.append(.quiet())


### PR DESCRIPTION
Hi, thanks for this repo, saved me some time!

Couple of small bug fixes for you.

- Defines the correct path for wkhtmltopdf on Linux while not distrupting macOS with #if(Linux)
- Manually closes the Pipe fd (this is a swift bug on linux that hasn't been fixed yet, there's no harm that I know of with this occuring on macOS as well)
- Updates the readme for macOS, I needed to use brew cask to instead of plain brew to install wkhtmltopdf on macOS

Thanks again!